### PR TITLE
Merging V1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,18 @@ ssc install repkit
 
 ## Install from GitHub repo
 
-TODO
+You can install older versions of `repkit` directly from the GitHub repository.
+To do so, start by finding the tag corresponding to
+the version you want to install here:
+https://github.com/dime-worldbank/repkit/tags.
+Update the local "tag" in the code below with the value of the tag you picked,
+and then run the code.
+
+```
+local tag "v1.0"
+net install repkit, ///
+  from("https://raw.githubusercontent.com/dime-worldbank/repkit/`tag`/src")
+```
 
 # Contributions
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,59 @@
 # repkit
 
-This Stata package is published by DIME Analytics and with tools related to computational reproducibility.
+This Stata module is package providing a utility toolkit
+for reproducibility best-practices.
+The motivation for this package is to make DIME Analytics'
+reproducibility best-practices more accessible to a wider Stata community.
+The best-practices promoted in this package appreciated
+identified and implemented as part of the
+[World Bank's reproducibility effort](https://reproducibility.worldbank.org/).
 
----
+Currently, this toolkit has the following commands:
+
+| Command | Description |
+| --- | --- |
+| [repado](https://dime-worldbank.github.io/repkit/reference/repado.html) | Command used to manage project ado command dependencies. This command provides a way to make sure that all team members as well as future reproducers of the projects code use the exact same version of all command dependencies. |
+| [repkit](https://dime-worldbank.github.io/repkit/reference/repkit.html) | Command named the same as the package. Most important purpose is that this command makes the code `which repkit` work. |
+
+# Installation
+
+While we allow multiple ways of installing the package,
+we recommend all users to install the package from SSC
+unless there is a very specific reason to not do so.
+
+## Install from SSC
+
+To install from SSC, run this code in your Stata command line.
+
+```
+ssc install repkit
+```
+
+## Install from GitHub repo
+
+TODO
+
+# Contributions
+
+This package is developed in
+[this repo](https://github.com/dime-worldbank/repkit)
+on GitHub using the [adodown](https://github.com/lsms-worldbank/adodown) workflow.
+
+We are happy to receive feedback and/or contributions.
+Please feel free to report bugs or request new features
+by opening up a
+[new issue](https://github.com/dime-worldbank/repkit/issues).
+
+You are also welcome to fork this repo and submit a
+[pull request](https://github.com/dime-worldbank/repkit/pulls)
+with contribution to the code.
+
+# Authors
+
+This package is written and published by
+[DIME Analytics](https://www.worldbank.org/en/research/dime/data-and-analytics).
+DIME Analytics is a research data methodology team part of the
+[Development Impact](https://www.worldbank.org/en/research/dime)
+department within the [World Bank](https://www.worldbank.org/).
 
 Contact: dimeanalytics@worldbank.org

--- a/src/ado/repado.ado
+++ b/src/ado/repado.ado
@@ -1,8 +1,12 @@
+*! version 1.0 05NOV2023 DIME Analytics dimeanalytics@worldbank.org
+
 cap program drop   repado
     program define repado
 
 qui {
     syntax , adopath(string) mode(string) [lessverbose]
+
+    version 13.0
 
     /***************************************************************************
     ****************************************************************************

--- a/src/ado/repkit.ado
+++ b/src/ado/repkit.ado
@@ -1,9 +1,13 @@
+*! version 1.0 05NOV2023 DIME Analytics dimeanalytics@worldbank.org
+
 cap program drop   repkit
     program define repkit, rclass
 
+    version 13.0
+
     * UPDATE THESE LOCALS FOR EACH NEW VERSION PUBLISHED
-  	local version "0.1"
-  	local versionDate "22AUG2023"
+  	local version "1.0"
+  	local versionDate "05NOV2023"
 
   	syntax [anything]
 

--- a/src/mdhlp/repado.md
+++ b/src/mdhlp/repado.md
@@ -46,6 +46,8 @@ repado , adopath("${myproj}/ado") mode("strict")
 
 # Feedback, bug reports and contributions
 
+Read more about the commands in this package at https://dime-worldbank.github.io/repkit.
+
 Please provide any feed back by opening and issue at https://github.com/dime-worldbank/repkit.
 
 PRs with suggestions for improvements are also greatly appreciated.

--- a/src/mdhlp/repkit.md
+++ b/src/mdhlp/repkit.md
@@ -20,6 +20,8 @@ This command has no options.
 
 # Feedback, bug reports and contributions
 
+Read more about the commands in this package at https://dime-worldbank.github.io/repkit.
+
 Please provide any feed back by opening and issue at https://github.com/dime-worldbank/repkit.
 
 PRs with suggestions for improvements are also greatly appreciated.

--- a/src/vignettes/ado-management-with-repado.md
+++ b/src/vignettes/ado-management-with-repado.md
@@ -57,7 +57,7 @@ Unless a specific new feature is required,
 it's advisable not to choose the most recent version to ensure
 reproducibility for as many users as possible.
 
-```
+```stata
   version 12.1
 ```
 


### PR DESCRIPTION
Merging version v1.0 of repkit. The only command so far is `repado` that is identical to the `adopath()` option of `ieboilstart` in `ietoolkit`.

