### PR TITLE
Merge space() into indent() for indentation handling (#91)

### DIFF
--- a/src/ado/lint.ado
+++ b/src/ado/lint.ado
@@ -11,7 +11,6 @@ program 	 lint
       NOSUMmary         			///
       Indent(string)    			///
       Linemax(string)   			///
-      Space(string) 				///
       Correct(string)   			///
       Excel(string)     			///
       AUTOmatic         			///
@@ -35,8 +34,18 @@ program 	 lint
   * set indent size = 4 if missing
   if missing("`indent'")		local indent "4"
 
-  * set whitespaces for tab (space) = indent size if space is missing
-  if missing("`space'")   		local space "`indent'"
+  * Set number of spaces used for indentation and tab replacement
+* Prefer indent(), fall back to space() for backward compatibility
+if ("`indent'" != "") {
+    local indentval = "`indent'"
+}
+else if ("`space'" != "") {
+    local indentval = "`space'"
+}
+else {
+    local indentval = 4
+}
+
 
   * set linemax = 80 if missing
   if missing("`linemax'")		local linemax "80"
@@ -157,7 +166,7 @@ _checkversions
 
 		_detect, ///
 			file("`file'") excel("`excel'") ado_path("`ado_path'") ///
-			indent("`indent'") linemax("`linemax'") space("`space'") ///
+			indent("`indentval'") linemax("`linemax'") ///
 			suppress_flag("`suppress_flag'") summary_flag("`summary_flag'") ///
 			`header' `footer'
     }
@@ -171,7 +180,7 @@ _checkversions
 
 			_detect, ///
 				file("`folder'/`file'") excel("`excel'") ado_path("`ado_path'") ///
-				indent("`indent'") linemax("`linemax'") space("`space'") ///
+				indent("`indentval'") linemax("`linemax'") ///
 				suppress_flag("`suppress_flag'") summary_flag("`summary_flag'") ///
 				header footer
 		}
@@ -188,7 +197,7 @@ _checkversions
 
 		_correct, ///
 			input("`input'") output("`output'") ///
-			indent("`indent'") space("`space'") linemax("`linemax'") ///
+			indent("`indentval'")linemax("`linemax'") ///
 			`replace' `force' `automatic' `debug'
 
 	}
@@ -209,7 +218,7 @@ program			_correct
 
 	syntax, ///
 		input(string) output(string) ///
-		indent(string) space(string) linemax(string) ///
+		indent(string) linemax(string) ///
 		[replace force automatic debug]
 
 	* Check that the Python function is defined
@@ -239,7 +248,7 @@ program			_correct
 	* Checking which issues are present in the dofile so we ask for their correction
 		python: Macro.setLocal('_delimiter',  str(slu.detect_delimit_in_file(r"`input'")))
 		python: Macro.setLocal('_hard_tab',   str(slu.detect_hard_tab_in_file(r"`input'")))
-		python: Macro.setLocal('_bad_indent', str(slu.detect_bad_indent_in_file(r"`input'", "`indent'", "`space'")))
+		python: Macro.setLocal('_bad_indent', str(slu.detect_bad_indent_in_file(r"`input'", "`indentval'", "`indentval'")))
 		python: Macro.setLocal('_long_lines', str(slu.detect_line_too_long_in_file(r"`input'", "`linemax'")))
 		python: Macro.setLocal('_no_space_before_curly', str(slu.detect_no_space_before_curly_bracket_in_file(r"`input'")))
 		python: Macro.setLocal('_blank_before_curly', str(slu.detect_blank_line_before_curly_close_in_file(r"`input'")))
@@ -359,7 +368,7 @@ program			_correct
 				    }
 				}
 
-		    python: `fun'(r"`output'", r"`output'", "`indent'", "`space'", "`linemax'")
+		    python: `fun'(r"`output'", r"`output'", "`indentval'", "`indentval'", "`linemax'")
 		}
     }
 
@@ -378,7 +387,7 @@ program			_detect
 
 		syntax , ///
 				file(string) ado_path(string) ///
-				indent(string) linemax(string) space(string) ///
+				indent(string) linemax(string) ///
 				suppress_flag(string) summary_flag(string) ///
 				[excel(string) header footer]
 
@@ -395,7 +404,7 @@ program			_detect
 		}
 
 		* Actually run the Python code
-        python: r = stata_linter_detect_py("`file'", "`indent'", "`suppress_flag'", "`summary_flag'", "`excel'", "`linemax'", "`space'")
+        python: r = stata_linter_detect_py("`file'", "`indentval'", "`suppress_flag'", "`summary_flag'", "`excel'", "`linemax'", "`indentval'")
 
 		* Stata result footer
 		if !missing("`footer'") {

--- a/src/ado/lint.ado
+++ b/src/ado/lint.ado
@@ -11,6 +11,7 @@ program 	 lint
       NOSUMmary         			///
       Indent(string)    			///
       Linemax(string)   			///
+      Space(string) 				///
       Correct(string)   			///
       Excel(string)     			///
       AUTOmatic         			///
@@ -34,18 +35,8 @@ program 	 lint
   * set indent size = 4 if missing
   if missing("`indent'")		local indent "4"
 
-  * Set number of spaces used for indentation and tab replacement
-* Prefer indent(), fall back to space() for backward compatibility
-if ("`indent'" != "") {
-    local indentval = "`indent'"
-}
-else if ("`space'" != "") {
-    local indentval = "`space'"
-}
-else {
-    local indentval = 4
-}
-
+  * set whitespaces for tab (space) = indent size if space is missing
+  if missing("`space'")   		local space "`indent'"
 
   * set linemax = 80 if missing
   if missing("`linemax'")		local linemax "80"
@@ -166,7 +157,7 @@ _checkversions
 
 		_detect, ///
 			file("`file'") excel("`excel'") ado_path("`ado_path'") ///
-			indent("`indentval'") linemax("`linemax'") ///
+			indent("`indent'") linemax("`linemax'") space("`space'") ///
 			suppress_flag("`suppress_flag'") summary_flag("`summary_flag'") ///
 			`header' `footer'
     }
@@ -180,7 +171,7 @@ _checkversions
 
 			_detect, ///
 				file("`folder'/`file'") excel("`excel'") ado_path("`ado_path'") ///
-				indent("`indentval'") linemax("`linemax'") ///
+				indent("`indent'") linemax("`linemax'") space("`space'") ///
 				suppress_flag("`suppress_flag'") summary_flag("`summary_flag'") ///
 				header footer
 		}
@@ -197,7 +188,7 @@ _checkversions
 
 		_correct, ///
 			input("`input'") output("`output'") ///
-			indent("`indentval'")linemax("`linemax'") ///
+			indent("`indent'") space("`space'") linemax("`linemax'") ///
 			`replace' `force' `automatic' `debug'
 
 	}
@@ -218,7 +209,7 @@ program			_correct
 
 	syntax, ///
 		input(string) output(string) ///
-		indent(string) linemax(string) ///
+		indent(string) space(string) linemax(string) ///
 		[replace force automatic debug]
 
 	* Check that the Python function is defined
@@ -248,7 +239,7 @@ program			_correct
 	* Checking which issues are present in the dofile so we ask for their correction
 		python: Macro.setLocal('_delimiter',  str(slu.detect_delimit_in_file(r"`input'")))
 		python: Macro.setLocal('_hard_tab',   str(slu.detect_hard_tab_in_file(r"`input'")))
-		python: Macro.setLocal('_bad_indent', str(slu.detect_bad_indent_in_file(r"`input'", "`indentval'", "`indentval'")))
+		python: Macro.setLocal('_bad_indent', str(slu.detect_bad_indent_in_file(r"`input'", "`indent'", "`space'")))
 		python: Macro.setLocal('_long_lines', str(slu.detect_line_too_long_in_file(r"`input'", "`linemax'")))
 		python: Macro.setLocal('_no_space_before_curly', str(slu.detect_no_space_before_curly_bracket_in_file(r"`input'")))
 		python: Macro.setLocal('_blank_before_curly', str(slu.detect_blank_line_before_curly_close_in_file(r"`input'")))
@@ -368,7 +359,7 @@ program			_correct
 				    }
 				}
 
-		    python: `fun'(r"`output'", r"`output'", "`indentval'", "`indentval'", "`linemax'")
+		    python: `fun'(r"`output'", r"`output'", "`indent'", "`space'", "`linemax'")
 		}
     }
 
@@ -387,7 +378,7 @@ program			_detect
 
 		syntax , ///
 				file(string) ado_path(string) ///
-				indent(string) linemax(string) ///
+				indent(string) linemax(string) space(string) ///
 				suppress_flag(string) summary_flag(string) ///
 				[excel(string) header footer]
 
@@ -404,7 +395,7 @@ program			_detect
 		}
 
 		* Actually run the Python code
-        python: r = stata_linter_detect_py("`file'", "`indentval'", "`suppress_flag'", "`summary_flag'", "`excel'", "`linemax'", "`indentval'")
+        python: r = stata_linter_detect_py("`file'", "`indent'", "`suppress_flag'", "`summary_flag'", "`excel'", "`linemax'", "`space'")
 
 		* Stata result footer
 		if !missing("`footer'") {

--- a/src/mdhlp/lint.md
+++ b/src/mdhlp/lint.md
@@ -25,7 +25,7 @@ For installing Python packages, refer to [this guide](https://blog.stata.com/202
 | __**v**erbose__ | Shows a report of all bad practices and issues flagged by the command. |
 | __**nosum**mary__ | Suppresses the summary table with counts of bad practices and potential issues. |
 | __**e**xcel__(_filename_) | Saves the verbose output in an Excel file. |
-| __**i**ndent__(_integer_) | Number of whitespaces used when checking indentation (default: 4). |
+| __**i**ndent__(_integer_) | Sets the number of spaces for indentation and replaces hard tabs with that number of spaces (default: 4). |
 | __**l**inemax__(_integer_) | Maximum number of characters in a line (default: 80). |
 
 ## Options specific to the correction mode
@@ -33,7 +33,6 @@ For installing Python packages, refer to [this guide](https://blog.stata.com/202
 | _options_ | Description |
 |-----------|-------------|
 | __**auto**matic__ | Suppresses the prompt asking users which correction to apply. |
-| __**s**pace__(_integer_) | Number of whitespaces used instead of hard tabs when replacing hard tabs with spaces for indentation (default: same value used for the option __indent()__, 4 when no value is defined). |
 | __replace__ | Allows the command to overwrite any existing _output_ file. |
 | __force__ | Allows the _input_file_ to be the same as _output_file_. Not recommended, see below. |
 
@@ -55,7 +54,7 @@ __**nosum**mary__ suppresses the summary table of flagged occurrences.
 
 __**e**xcel__(_filename_) exports the verbose output to an Excel file at the specified location.
 
-__**i**ndent__(_integer_) sets the number of whitespaces used when checking indentation. Default: 4.
+| __**i**ndent__(_integer_) | Sets the number of spaces for indentation and replaces hard tabs with that number of spaces (default: 4). |
 
 __**l**inemax__(_integer_) sets the maximum number of characters allowed in a single line. Default: 80.
 

--- a/src/sthlp/lint.sthlp
+++ b/src/sthlp/lint.sthlp
@@ -1,5 +1,5 @@
 {smcl}
-{* *! version 3.4 20250609}{...}
+{* *! version NOPKGMETA NOPKGMETA}{...}
 {hline}
 {pstd}help file for {hi:lint}{p_end}
 {hline}
@@ -39,17 +39,16 @@ For installing Python packages, refer to {browse "https://blog.stata.com/2020/09
 {synopt: {bf:{ul:v}erbose}}Shows a report of all bad practices and issues flagged by the command.{p_end}
 {synopt: {bf:{ul:nosum}mary}}Suppresses the summary table with counts of bad practices and potential issues.{p_end}
 {synopt: {bf:{ul:e}xcel}({it:filename})}Saves the verbose output in an Excel file.{p_end}
-{synopt: {bf:{ul:i}ndent}({it:integer})}Number of whitespaces used when checking indentation (default: 4).{p_end}
+{synopt: {bf:{ul:i}ndent}({it:integer})}Sets the number of spaces for indentation and replaces hard tabs with that number of spaces (default: 4).{p_end}
 {synopt: {bf:{ul:l}inemax}({it:integer})}Maximum number of characters in a line (default: 80).{p_end}
 {synoptline}
 
 {dlgtab:Options specific to the correction mode}
 
-{synoptset 14}{...}
+{synoptset 9}{...}
 {p2coldent:{it:options}}Description{p_end}
 {synoptline}
 {synopt: {bf:{ul:auto}matic}}Suppresses the prompt asking users which correction to apply.{p_end}
-{synopt: {bf:{ul:s}pace}({it:integer})}Number of whitespaces used instead of hard tabs when replacing hard tabs with spaces for indentation (default: same value used for the option {bf:indent()}, 4 when no value is defined).{p_end}
 {synopt: {bf:replace}}Allows the command to overwrite any existing {it:output} file.{p_end}
 {synopt: {bf:force}}Allows the {it:input_file} to be the same as {it:output_file}. Not recommended, see below.{p_end}
 {synoptline}
@@ -77,8 +76,10 @@ See the list of rules and the DIME Analytics Stata Style Guide for a discussion 
 {pstd}{bf:{ul:e}xcel}({it:filename}) exports the verbose output to an Excel file at the specified location.
 {p_end}
 
-{pstd}{bf:{ul:i}ndent}({it:integer}) sets the number of whitespaces used when checking indentation. Default: 4.
-{p_end}
+{synoptset 0}{...}
+{p2coldent:{bf:{ul:i}ndent}({it:integer})}Sets the number of spaces for indentation and replaces hard tabs with that number of spaces (default: 4).{p_end}
+{synoptline}
+{synoptline}
 
 {pstd}{bf:{ul:l}inemax}({it:integer}) sets the maximum number of characters allowed in a single line. Default: 80.
 {p_end}


### PR DESCRIPTION
This edit merges the indent() and space() options into a single interface. It:

- Removes space() from all syntax blocks and user-facing documentation
- Introduces a new internal variable indentval that is set to:
-                  indent() if provided
-                  space() if only it is provided (for backward compatibility)
-                  Defaults to 4 otherwise
- Uses indentval consistently for both indentation detection and hard tab replacement

